### PR TITLE
Bugfix: Make tabs accessible again after zooming to a feature

### DIFF
--- a/app/src/main/java/mil/nga/msi/Utils.kt
+++ b/app/src/main/java/mil/nga/msi/Utils.kt
@@ -1,5 +1,9 @@
 package mil.nga.msi
 
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.navOptions
 import mil.nga.sf.Geometry
 import mil.nga.sf.GeometryEnvelope
 import mil.nga.sf.LineString
@@ -42,3 +46,12 @@ fun getPointsForGeometry(geometry: Geometry): List<Point> {
    }
 }
 
+fun buildZoomNavOptions(navController: NavController): NavOptions {
+   return navOptions {
+      popUpTo(navController.graph.findStartDestination().id) {
+         saveState = true
+         inclusive = true
+      }
+      launchSingleTop = true
+   }
+}

--- a/app/src/main/java/mil/nga/msi/ui/action/AsamAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/AsamAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.asam.Asam
 import mil.nga.msi.ui.asam.AsamRoute
 import mil.nga.msi.ui.map.MapRoute
@@ -21,7 +22,7 @@ sealed class AsamAction : Action() {
       override fun navigate(navController: NavController) {
          val point = NavPoint(latLng.latitude, latLng.longitude)
          val encoded = Uri.encode(Json.encodeToString(point))
-         navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
       }
    }
 

--- a/app/src/main/java/mil/nga/msi/ui/action/DgpsStationAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/DgpsStationAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.dgpsstation.DgpsStation
 import mil.nga.msi.repository.dgpsstation.DgpsStationKey
 import mil.nga.msi.ui.dgpsstation.DgpsStationRoute
@@ -24,7 +25,7 @@ sealed class DgpsStationAction : Action() {
       override fun navigate(navController: NavController) {
          val point = NavPoint(latLng.latitude, latLng.longitude)
          val encoded = Uri.encode(Json.encodeToString(point))
-         navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
       }
    }
 

--- a/app/src/main/java/mil/nga/msi/ui/action/GeoPackageFeatureAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/GeoPackageFeatureAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.repository.geopackage.GeoPackageFeatureKey
 import mil.nga.msi.ui.geopackage.GeoPackageRoute
 import mil.nga.msi.ui.map.MapRoute
@@ -22,7 +23,7 @@ sealed class GeoPackageFeatureAction : Action() {
       override fun navigate(navController: NavController) {
          val point = NavPoint(latLng.latitude, latLng.longitude)
          val encoded = Uri.encode(Json.encodeToString(point))
-         navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
       }
    }
 

--- a/app/src/main/java/mil/nga/msi/ui/action/LightAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/LightAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.light.Light
 import mil.nga.msi.repository.light.LightKey
 import mil.nga.msi.ui.light.LightRoute
@@ -24,7 +25,7 @@ sealed class LightAction : Action() {
       override fun navigate(navController: NavController) {
          val point = NavPoint(latLng.latitude, latLng.longitude)
          val encoded = Uri.encode(Json.encodeToString(point))
-         navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
       }
    }
 

--- a/app/src/main/java/mil/nga/msi/ui/action/ModuAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/ModuAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.maps.android.SphericalUtil
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.modu.Modu
 import mil.nga.msi.ui.map.MapRoute
 import mil.nga.msi.ui.modu.ModuRoute
@@ -24,7 +25,7 @@ sealed class ModuAction : Action() {
          if (radius == null) {
             val point = NavPoint(modu.latLng.latitude, modu.latLng.longitude)
             val encoded = Uri.encode(Json.encodeToString(point))
-            navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+            navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
          } else {
             val radiusInMeters = radius * 1852
             val northBound = SphericalUtil.computeOffset(modu.latLng, radiusInMeters, 0.0)
@@ -38,7 +39,7 @@ sealed class ModuAction : Action() {
                eastBound.longitude
             )
             val encodedBounds = Uri.encode(Json.encodeToString(bounds))
-            navController.navigate(MapRoute.Map.name + "?bounds=${encodedBounds}")
+            navController.navigate(MapRoute.Map.name + "?bounds=${encodedBounds}", buildZoomNavOptions(navController))
          }
       }
    }

--- a/app/src/main/java/mil/nga/msi/ui/action/NavigationalWarningAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/NavigationalWarningAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLngBounds
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.DataSource
 import mil.nga.msi.datasource.navigationwarning.NavigationArea
 import mil.nga.msi.datasource.navigationwarning.NavigationalWarning
@@ -31,7 +32,7 @@ sealed class NavigationalWarningAction : Action() {
    class Zoom(val bounds: LatLngBounds): Action() {
       override fun navigate(navController: NavController) {
          val encoded = Uri.encode(Json.encodeToString(Bounds.fromLatLngBounds(bounds)))
-         navController.navigate(MapRoute.Map.name + "?bounds=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?bounds=${encoded}", buildZoomNavOptions(navController))
       }
    }
 

--- a/app/src/main/java/mil/nga/msi/ui/action/PortAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/PortAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.port.Port
 import mil.nga.msi.ui.map.MapRoute
 import mil.nga.msi.ui.navigation.NavPoint
@@ -21,7 +22,7 @@ sealed class PortAction: Action() {
       override fun navigate(navController: NavController) {
          val point = NavPoint(latLng.latitude, latLng.longitude)
          val encoded = Uri.encode(Json.encodeToString(point))
-         navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
       }
    }
 

--- a/app/src/main/java/mil/nga/msi/ui/action/RadioBeaconAction.kt
+++ b/app/src/main/java/mil/nga/msi/ui/action/RadioBeaconAction.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mil.nga.msi.buildZoomNavOptions
 import mil.nga.msi.datasource.radiobeacon.RadioBeacon
 import mil.nga.msi.repository.radiobeacon.RadioBeaconKey
 import mil.nga.msi.ui.map.MapRoute
@@ -24,7 +25,7 @@ sealed class RadioBeaconAction : Action() {
       override fun navigate(navController: NavController) {
          val point = NavPoint(latLng.latitude, latLng.longitude)
          val encoded = Uri.encode(Json.encodeToString(point))
-         navController.navigate(MapRoute.Map.name + "?point=${encoded}")
+         navController.navigate(MapRoute.Map.name + "?point=${encoded}", buildZoomNavOptions(navController))
       }
    }
 


### PR DESCRIPTION
This change adds navOptions to the "zoom to feature" calls to prevent them from replacing their tabs' contents with the map.