### PR TITLE
Fix crashes when copying coordinates from certain screens

### DIFF
--- a/app/src/main/java/mil/nga/msi/ui/dgpsstation/list/DgpsStationsScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/dgpsstation/list/DgpsStationsScreen.kt
@@ -24,7 +24,6 @@ import mil.nga.msi.datasource.dgpsstation.DgpsStation
 import mil.nga.msi.datasource.dgpsstation.DgpsStationWithBookmark
 import mil.nga.msi.repository.bookmark.BookmarkKey
 import mil.nga.msi.ui.action.Action
-import mil.nga.msi.ui.action.AsamAction
 import mil.nga.msi.ui.action.DgpsStationAction
 import mil.nga.msi.ui.datasource.DataSourceActions
 import mil.nga.msi.ui.dgpsstation.DgpsStationRoute

--- a/app/src/main/java/mil/nga/msi/ui/dgpsstation/list/DgpsStationsScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/dgpsstation/list/DgpsStationsScreen.kt
@@ -90,7 +90,7 @@ fun DgpsStationsScreen(
                   viewModel.deleteBookmark(bookmark)
                }
             },
-            onCopyLocation = { onAction(AsamAction.Location(it)) }
+            onCopyLocation = { onAction(DgpsStationAction.Location(it)) }
          )
 
          Box(

--- a/app/src/main/java/mil/nga/msi/ui/light/detail/LightDetailScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/light/detail/LightDetailScreen.kt
@@ -95,7 +95,7 @@ fun LightDetailScreen(
                viewModel.deleteBookmark(bookmark)
             }
          },
-         onCopyLocation = { onAction(AsamAction.Location(it)) }
+         onCopyLocation = { onAction(LightAction.Location(it)) }
       )
    }
 }

--- a/app/src/main/java/mil/nga/msi/ui/light/detail/LightDetailScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/light/detail/LightDetailScreen.kt
@@ -50,7 +50,6 @@ import mil.nga.msi.datasource.light.LightWithBookmark
 import mil.nga.msi.repository.bookmark.BookmarkKey
 import mil.nga.msi.repository.light.LightKey
 import mil.nga.msi.ui.action.Action
-import mil.nga.msi.ui.action.AsamAction
 import mil.nga.msi.ui.action.LightAction
 import mil.nga.msi.ui.bookmark.BookmarkNotes
 import mil.nga.msi.ui.datasource.DataSourceActions

--- a/app/src/main/java/mil/nga/msi/ui/modu/list/ModusScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/modu/list/ModusScreen.kt
@@ -90,7 +90,7 @@ fun ModusScreen(
                   viewModel.deleteBookmark(bookmark)
                }
             },
-            onCopyLocation = { onAction(AsamAction.Location(it)) }
+            onCopyLocation = { onAction(ModuAction.Location(it)) }
          )
 
          Box(

--- a/app/src/main/java/mil/nga/msi/ui/modu/list/ModusScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/modu/list/ModusScreen.kt
@@ -24,7 +24,6 @@ import mil.nga.msi.datasource.modu.Modu
 import mil.nga.msi.datasource.modu.ModuWithBookmark
 import mil.nga.msi.repository.bookmark.BookmarkKey
 import mil.nga.msi.ui.action.Action
-import mil.nga.msi.ui.action.AsamAction
 import mil.nga.msi.ui.main.TopBar
 import mil.nga.msi.ui.action.ModuAction
 import mil.nga.msi.ui.datasource.DataSourceActions

--- a/app/src/main/java/mil/nga/msi/ui/port/list/PortsScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/port/list/PortsScreen.kt
@@ -93,7 +93,7 @@ fun PortsScreen(
                   viewModel.deleteBookmark(bookmark)
                }
             },
-            onCopyLocation = { onAction(AsamAction.Location(it)) }
+            onCopyLocation = { onAction(PortAction.Location(it)) }
          )
 
          Box(

--- a/app/src/main/java/mil/nga/msi/ui/port/list/PortsScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/port/list/PortsScreen.kt
@@ -25,7 +25,6 @@ import mil.nga.msi.datasource.port.Port
 import mil.nga.msi.datasource.port.PortWithBookmark
 import mil.nga.msi.repository.bookmark.BookmarkKey
 import mil.nga.msi.ui.action.Action
-import mil.nga.msi.ui.action.AsamAction
 import mil.nga.msi.ui.main.TopBar
 import mil.nga.msi.ui.action.PortAction
 import mil.nga.msi.ui.datasource.DataSourceActions

--- a/app/src/main/java/mil/nga/msi/ui/radiobeacon/list/RadioBeaconsScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/radiobeacon/list/RadioBeaconsScreen.kt
@@ -90,7 +90,7 @@ fun RadioBeaconsScreen(
                   viewModel.deleteBookmark(bookmark)
                }
             },
-            onCopyLocation = { onAction(AsamAction.Location(it)) }
+            onCopyLocation = { onAction(RadioBeaconAction.Location(it)) }
          )
 
          Box(

--- a/app/src/main/java/mil/nga/msi/ui/radiobeacon/list/RadioBeaconsScreen.kt
+++ b/app/src/main/java/mil/nga/msi/ui/radiobeacon/list/RadioBeaconsScreen.kt
@@ -24,7 +24,6 @@ import mil.nga.msi.datasource.radiobeacon.RadioBeacon
 import mil.nga.msi.datasource.radiobeacon.RadioBeaconWithBookmark
 import mil.nga.msi.repository.bookmark.BookmarkKey
 import mil.nga.msi.ui.action.Action
-import mil.nga.msi.ui.action.AsamAction
 import mil.nga.msi.ui.main.TopBar
 import mil.nga.msi.ui.action.RadioBeaconAction
 import mil.nga.msi.ui.datasource.DataSourceActions


### PR DESCRIPTION
The copy coordinates action didn't match the current datasource for some screens. This caused the app to crash after copying coordinates.